### PR TITLE
[Feature] Add organization id to User

### DIFF
--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -30,10 +30,11 @@ class AuthKitAuthenticationRequest extends FormRequest
             $this->query('code'),
         );
 
-        [$user, $accessToken, $refreshToken] = [
+        [$user, $accessToken, $refreshToken, $organizationId] = [
             $user->user,
             $user->access_token,
             $user->refresh_token,
+            $user->organization_id,
         ];
 
         $user = new User(
@@ -41,6 +42,7 @@ class AuthKitAuthenticationRequest extends FormRequest
             firstName: $user->firstName,
             lastName: $user->lastName,
             email: $user->email,
+            organizationId: $organizationId,
             avatar: $user->profilePictureUrl,
         );
 

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -39,10 +39,10 @@ class AuthKitAuthenticationRequest extends FormRequest
 
         $user = new User(
             id: $user->id,
+            organizationId: $organizationId,
             firstName: $user->firstName,
             lastName: $user->lastName,
             email: $user->email,
-            organizationId: $organizationId,
             avatar: $user->profilePictureUrl,
         );
 

--- a/src/User.php
+++ b/src/User.php
@@ -6,10 +6,10 @@ class User
 {
     public function __construct(
         public string $id,
+        public ?string $organizationId,
         public ?string $firstName,
         public ?string $lastName,
         public string $email,
-        public ?string $organizationId,
         public ?string $avatar = null,
     ) {}
 }

--- a/src/User.php
+++ b/src/User.php
@@ -9,6 +9,7 @@ class User
         public ?string $firstName,
         public ?string $lastName,
         public string $email,
+        public ?string $organizationId,
         public ?string $avatar = null,
     ) {}
 }


### PR DESCRIPTION
WorkOS supports _Organizations_ which are essentially teams (a user can belong to many organizations). This PR adds the `organizationId` passed from WorkOS back to the User object.

This allows us to hook into the  exposed `createUsing` callback on the `authenticate` method to receive that organizationId and store it/attach the user model to a team.

In my use case I'm planning on building out teams that leverage organizations, so having this will allow me to associate the user with a team when they're invited to app.