### PR TITLE
Use service container

### DIFF
--- a/src/Http/Middleware/ValidateSessionWithWorkOS.php
+++ b/src/Http/Middleware/ValidateSessionWithWorkOS.php
@@ -20,7 +20,7 @@ class ValidateSessionWithWorkOS
             return $next($request);
         }
 
-        WorkOS::configure();
+        app(WorkOS::class)::configure();
 
         if (! $request->session()->get('workos_access_token') ||
             ! $request->session()->get('workos_refresh_token')) {
@@ -28,7 +28,7 @@ class ValidateSessionWithWorkOS
         }
 
         try {
-            [$accessToken, $refreshToken] = WorkOS::ensureAccessTokenIsValid(
+            [$accessToken, $refreshToken] = app(WorkOS::class)::ensureAccessTokenIsValid(
                 $request->session()->get('workos_access_token'),
                 $request->session()->get('workos_refresh_token'),
             );

--- a/src/Http/Requests/AuthKitAccountDeletionRequest.php
+++ b/src/Http/Requests/AuthKitAccountDeletionRequest.php
@@ -22,7 +22,7 @@ class AuthKitAccountDeletionRequest extends FormRequest
         if (isset($user->workos_id) && ! app()->runningUnitTests()) {
             WorkOS::configure();
 
-            (new UserManagement)->deleteUser(
+            app(UserManagement::class)->deleteUser(
                 $user->workos_id
             );
         }

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -34,12 +34,10 @@ class AuthKitAuthenticationRequest extends FormRequest
         );
 
         [$user, $accessToken, $refreshToken] = [
-            $user->user,
+            $makeUsing($user),
             $user->access_token,
             $user->refresh_token,
         ];
-
-        $user = $makeUsing($user);
 
         $existingUser = $findUsing($user->id);
 
@@ -61,8 +59,10 @@ class AuthKitAuthenticationRequest extends FormRequest
         return $existingUser;
     }
 
-    protected function makeUsing(ResourceUser $user): User
+    protected function makeUsing(AuthenticationResponse $response): User
     {
+        $user = $response->user;
+
         return  app()->make(User::class, [
             'id' => $user->id,
             'firstName' => $user->firstName,

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\WorkOS\User;
 use Laravel\WorkOS\WorkOS;
 use WorkOS\Resource\AuthenticationResponse;
-use WorkOS\Resource\User as ResourceUser;
 use WorkOS\UserManagement;
 
 class AuthKitAuthenticationRequest extends FormRequest

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -17,7 +17,7 @@ class AuthKitAuthenticationRequest extends FormRequest
      */
     public function authenticate(?callable $findUsing = null, ?callable $createUsing = null, ?callable $updateUsing = null): mixed
     {
-        WorkOS::configure();
+        app(WorkOS::class)::configure();
 
         $this->ensureStateIsValid();
 
@@ -25,7 +25,7 @@ class AuthKitAuthenticationRequest extends FormRequest
         $createUsing ??= $this->createUsing(...);
         $updateUsing ??= $this->updateUsing(...);
 
-        $user = (new UserManagement)->authenticateWithCode(
+        $user = app(UserManagement::class)->authenticateWithCode(
             config('services.workos.client_id'),
             $this->query('code'),
         );
@@ -36,13 +36,13 @@ class AuthKitAuthenticationRequest extends FormRequest
             $user->refresh_token,
         ];
 
-        $user = new User(
-            id: $user->id,
-            firstName: $user->firstName,
-            lastName: $user->lastName,
-            email: $user->email,
-            avatar: $user->profilePictureUrl,
-        );
+        $user = app()->make(User::class, [
+            'id' => $user->id,
+            'firstName' => $user->firstName,
+            'lastName' => $user->lastName,
+            'email' => $user->email,
+            'avatar' => $user->profilePictureUrl,
+        ]);
 
         $existingUser = $findUsing($user->id);
 

--- a/src/Http/Requests/AuthKitLoginRequest.php
+++ b/src/Http/Requests/AuthKitLoginRequest.php
@@ -16,9 +16,9 @@ class AuthKitLoginRequest extends FormRequest
      */
     public function redirect(): Response
     {
-        WorkOS::configure();
+        app(WorkOS::class)::configure();
 
-        $url = (new UserManagement)->getAuthorizationUrl(
+        $url = app(UserManagement::class)->getAuthorizationUrl(
             config('services.workos.redirect_url'),
             ['state' => $state = Str::random(20)],
             'authkit',

--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -19,7 +19,7 @@ class AuthKitLogoutRequest extends FormRequest
         $accessToken = $this->session()->get('workos_access_token');
 
         $workOsSession = $accessToken
-            ? WorkOS::decodeAccessToken($accessToken)
+            ? app(WorkOS::class)::decodeAccessToken($accessToken)
             : false;
 
         Auth::guard('web')->logout();
@@ -31,7 +31,7 @@ class AuthKitLogoutRequest extends FormRequest
             return redirect('/');
         }
 
-        $logoutUrl = (new UserManagement)->getLogoutUrl(
+        $logoutUrl = app(UserManagement::class)->getLogoutUrl(
             $workOsSession['sid'],
         );
 

--- a/src/WorkOS.php
+++ b/src/WorkOS.php
@@ -26,7 +26,7 @@ class WorkOS
             throw new RuntimeException("The 'services.workos.redirect_url' configuration value is undefined.");
         }
 
-        SDK::setClientId(config('services.workos.client_id'));
+        app(SDK::class)::setClientId(config('services.workos.client_id'));
     }
 
     /**
@@ -39,7 +39,7 @@ class WorkOS
         $workOsSession = static::decodeAccessToken($accessToken);
 
         if (! $workOsSession) {
-            $result = (new UserManagement)->authenticateWithRefreshToken(
+            $result = app(UserManagement::class)->authenticateWithRefreshToken(
                 config('services.workos.client_id'), $refreshToken
             );
 
@@ -78,7 +78,7 @@ class WorkOS
     {
         return Cache::remember('workos:jwk', now()->addHours(12), function () {
             return Http::get(
-                (new UserManagement)->getJwksUrl(config('services.workos.client_id'))
+                app(UserManagement::class)->getJwksUrl(config('services.workos.client_id'))
             )->json();
         });
     }


### PR DESCRIPTION
https://github.com/laravel/workos/pull/2
https://github.com/laravel/workos/pull/1

Workos supports a wide range of clients and protocols. This PR Uses the service container for the workos services, so that they can be decorated or extended on a per case, per needs basis by the developer, rather than attempt to support the delta of every possible use case here manually.

Edit: Also adds a `makeUsing` callback to the `AuthKitAuthenticationRequest`

Example Usage:

```php
// routes/auth.php

use Illuminate\Support\Facades\Route;
use Laravel\WorkOS\Http\Requests\AuthKitAuthenticationRequest;
use Laravel\WorkOS\User;
use WorkOS\Resource\AuthenticationResponse;

Route::get('authenticate', function (AuthKitAuthenticationRequest $request) {
    return tap(to_route('dashboard'), fn () => $request->authenticate(makeUsing: function (AuthenticationResponse $response) {
        $user = $response->user;

        return new class($user->id, $user->firstName, $user->lastName, $user->email, $user->profilePictureUrl, $response->organizationId) extends User
        {
            public function __construct(
                public string $id,
                public ?string $firstName,
                public ?string $lastName,
                public string $email,
                public ?string $avatar,
                public ?string $organizationId,
            ) {}
        };
    }));
})->middleware(['guest']);
```