### PR TITLE
[Fix] Organization variable mapping

### DIFF
--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -34,7 +34,7 @@ class AuthKitAuthenticationRequest extends FormRequest
             $user->user,
             $user->access_token,
             $user->refresh_token,
-            $user->organization_id,
+            $user->organizationId,
         ];
 
         $user = new User(


### PR DESCRIPTION
The WorkOS `UserManagement` class maps the organization id back to `organizationId` instead of `organization_id`.