### PR TITLE
[Feature/Fix] Redirect users back to previous URL upon sign in

### DIFF
--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -107,7 +107,7 @@ class AuthKitAuthenticationRequest extends FormRequest
      */
     public function redirect(string $default = '/'): Response
     {
-        $url = rtrim(base64_decode(json_decode($this->session()->get('state'), true)['previous_url'] ?? '/')) ?: null;
+        $url = rtrim(base64_decode($this->sessionState()['previous_url'] ?? '/')) ?: null;
 
         $to = ! is_null($url) && $url !== URL::to('/')
             ? $url
@@ -125,10 +125,18 @@ class AuthKitAuthenticationRequest extends FormRequest
     {
         $state = json_decode($this->query('state'), true)['state'] ?? false;
 
-        if ($state !== (json_decode($this->session()->get('state'), true)['state'] ?? false)) {
+        if ($state !== ($this->sessionState()['state'] ?? false)) {
             abort(403);
         }
 
         $this->session()->forget('state');
+    }
+
+    /**
+     * Get the session state.
+     */
+    protected function sessionState(): array
+    {
+        return json_decode($this->session()->get('state'), true) ?: [];
     }
 }

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -103,14 +103,14 @@ class AuthKitAuthenticationRequest extends FormRequest
     }
 
     /**
-     * Redirect the user to the previous or default URL.
+     * Redirect the user to the previous URL or a default URL if no previous URL is available.
      */
     public function redirect(string $default = '/'): Response
     {
-        $url = rtrim(base64_decode($this->sessionState()['previous_url'] ?? '/')) ?: null;
+        $previousUrl = rtrim(base64_decode($this->sessionState()['previous_url'] ?? '/')) ?: null;
 
-        $to = ! is_null($url) && $url !== URL::to('/')
-            ? $url
+        $to = ! is_null($previousUrl) && $previousUrl !== URL::to('/')
+            ? $previousUrl
             : $default;
 
         return class_exists(Inertia::class)

--- a/src/Http/Requests/AuthKitLoginRequest.php
+++ b/src/Http/Requests/AuthKitLoginRequest.php
@@ -3,6 +3,8 @@
 namespace Laravel\WorkOS\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\WorkOS\WorkOS;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,11 +21,14 @@ class AuthKitLoginRequest extends FormRequest
 
         $url = (new UserManagement)->getAuthorizationUrl(
             config('services.workos.redirect_url'),
-            ['state' => $state = base64_encode(url()->previous())],
+            $state = [
+                'state' => Str::random(20),
+                'previous_url' => base64_encode(URL::previous()),
+            ],
             'authkit',
         );
 
-        $this->session()->put('state', $state);
+        $this->session()->put('state', json_encode($state));
 
         return class_exists(Inertia::class)
             ? Inertia::location($url)

--- a/src/Http/Requests/AuthKitLoginRequest.php
+++ b/src/Http/Requests/AuthKitLoginRequest.php
@@ -3,7 +3,6 @@
 namespace Laravel\WorkOS\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\WorkOS\WorkOS;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +19,7 @@ class AuthKitLoginRequest extends FormRequest
 
         $url = (new UserManagement)->getAuthorizationUrl(
             config('services.workos.redirect_url'),
-            ['state' => $state = Str::random(20)],
+            ['state' => $state = base64_encode(url()->previous())],
             'authkit',
         );
 


### PR DESCRIPTION
tl;dr

* Does not contain any breaking changes
* Fixes inviting users from WorkOS directly (currently users would get a 403)
* Allows user to specify a default redirect location and redirects them to the requested page 

## Fix

Currently the `state` parameter is being set to a [random 20 character string](https://github.com/laravel/workos/blob/44bcd571db5a78b9eba53107a8731606e46cbec3/src/Http/Requests/AuthKitLoginRequest.php#L23) upon being redirected to WorkOS for authentication. The state parameter is being used as an extra "check" to ensure the log in is valid with the `ensureStateIsValid` [method](https://github.com/laravel/workos/blob/44bcd571db5a78b9eba53107a8731606e46cbec3/src/Http/Requests/AuthKitAuthenticationRequest.php#L105). Per WorkOS, we don't need to use the state parameter to ensure any integrity and can use it to pass information to restore state:

``
Additionally, WorkOS can pass a state parameter back to your application that you may use to encode arbitrary information to restore your application state between the redirects.
``

Unfortunately, the current random string state breaks the invitation system:

- If we invite a user to an app from WorkOS directly. They'll get an invitation via email from WorkOS to register.
- Upon registering WorkOS redirects them as they have been authenticated.
- The user gets a 403 as there is no `state` variable set from hitting the /login route.

This PR fixes this by not enforcing that the `state` variable is present. I'm building out a private application where there is no public registration and users will be invited through WorkOS.

## Redirecting/Setting default route

This PR encode the previous URL upon hitting the `/login` route and will allow us to redirect users back. For example if an unauthenticated user goes to https://contoso.test/settings, they'll be redirected to WorkOS for auth, and then back to the settings page.

Currently the WorkOS scaffolding sets the default route to `dashboard`.

```php
return tap(to_route('dashboard'), fn () => $request->authenticate());
```

With this PR the above still works fine, but if the user wants the scaffolding to redirect back to the previous URL they can update their login route to while also setting a default location:

```php
return tap($request->redirect(default: '/dashboard'), fn () => $request->authenticate());
```


