### PR TITLE
Fix for https://github.com/laravel/framework/issues/55028

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",
         "workos/workos-php": "^4.18",
+        "workos/workos-php-laravel": "^4.1",
         "firebase/php-jwt": "^6.11"
     },
     "require-dev": {


### PR DESCRIPTION
Fix for issue 55028 where WorkOS complains it can't access $apiKey/etc when the config is cached