### PR TITLE
Fix missing `WORKOS_API_KEY` registration

### DIFF
--- a/src/WorkOS.php
+++ b/src/WorkOS.php
@@ -31,7 +31,6 @@ class WorkOS
         }
 
         SDK::setClientId(config('services.workos.client_id'));
-
         SDK::setApiKey(config('services.workos.secret'));
     }
 

--- a/src/WorkOS.php
+++ b/src/WorkOS.php
@@ -20,6 +20,10 @@ class WorkOS
     {
         if (! config('services.workos.client_id')) {
             throw new RuntimeException("The 'services.workos.client_id' configuration value is undefined.");
+        } 
+
+        if (! config('services.workos.secret')) {
+            throw new RuntimeException("The 'services.workos.secret' configuration value is undefined.");
         }
 
         if (! config('services.workos.redirect_url')) {
@@ -27,6 +31,7 @@ class WorkOS
         }
 
         SDK::setClientId(config('services.workos.client_id'));
+        SDK::setApiKey(config('services.workos.secret'));
     }
 
     /**

--- a/src/WorkOS.php
+++ b/src/WorkOS.php
@@ -20,7 +20,7 @@ class WorkOS
     {
         if (! config('services.workos.client_id')) {
             throw new RuntimeException("The 'services.workos.client_id' configuration value is undefined.");
-        } 
+        }
 
         if (! config('services.workos.secret')) {
             throw new RuntimeException("The 'services.workos.secret' configuration value is undefined.");

--- a/src/WorkOS.php
+++ b/src/WorkOS.php
@@ -31,6 +31,7 @@ class WorkOS
         }
 
         SDK::setClientId(config('services.workos.client_id'));
+
         SDK::setApiKey(config('services.workos.secret'));
     }
 


### PR DESCRIPTION
fixes laravel/framework#55028

without direct registration from config `workos-php` would rely from `getenv('WORKOS_API_KEY')` and this is not available when application uses cached config
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
