### PR TITLE
feat: decide profile update by adding allowUpdate parameter

### DIFF
--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -18,7 +18,7 @@ class AuthKitAuthenticationRequest extends FormRequest
     /**
      * Redirect the user to WorkOS for authentication.
      */
-    public function authenticate(?callable $findUsing = null, ?callable $createUsing = null, ?callable $updateUsing = null): mixed
+    public function authenticate(?callable $findUsing = null, ?callable $createUsing = null, ?callable $updateUsing = null, bool $allowUpdate = true): mixed
     {
         WorkOS::configure();
 
@@ -55,7 +55,7 @@ class AuthKitAuthenticationRequest extends FormRequest
             $existingUser = $createUsing($user);
 
             event(new Registered($existingUser));
-        } elseif (! is_null($updateUsing)) {
+        } elseif (! is_null($updateUsing) && $allowUpdate) {
             $existingUser = $updateUsing($existingUser, $user);
         }
 


### PR DESCRIPTION
Problem with existing users: Every time they log in, their profile updates to the latest data they have on their social account. 

There should be a control over that, depending on the use case.