### PR TITLE
Customize the return/redirect URL on logout request

### DIFF
--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -14,7 +14,7 @@ class AuthKitLogoutRequest extends FormRequest
     /**
      * Redirect the user to WorkOS for authentication.
      */
-    public function logout(): Response
+    public function logout(?string $returnTo = null): Response
     {
         $accessToken = $this->session()->get('workos_access_token');
 
@@ -28,11 +28,12 @@ class AuthKitLogoutRequest extends FormRequest
         $this->session()->regenerateToken();
 
         if (! $workOsSession) {
-            return redirect('/');
+            return redirect($returnTo ?? '/');
         }
 
         $logoutUrl = (new UserManagement)->getLogoutUrl(
             $workOsSession['sid'],
+            $returnTo ? url($returnTo) : null,
         );
 
         return class_exists(Inertia::class)

--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -14,7 +14,7 @@ class AuthKitLogoutRequest extends FormRequest
     /**
      * Redirect the user to WorkOS for authentication.
      */
-    public function logout(?string $returnTo = null): Response
+    public function logout(?string $redirectTo = null): Response
     {
         $accessToken = $this->session()->get('workos_access_token');
 
@@ -28,12 +28,12 @@ class AuthKitLogoutRequest extends FormRequest
         $this->session()->regenerateToken();
 
         if (! $workOsSession) {
-            return redirect($returnTo ?? '/');
+            return redirect($redirectTo ?? '/');
         }
 
         $logoutUrl = (new UserManagement)->getLogoutUrl(
             $workOsSession['sid'],
-            $returnTo ? url($returnTo) : null,
+            $redirectTo ? url($redirectTo) : null,
         );
 
         return class_exists(Inertia::class)


### PR DESCRIPTION
This PR allows customizing the return/redirect URL when logging out.
Scenario I encountered when using a WorkOS staging environment where this would be useful:

Configured "Logout redirects" in WorkOS:

* local-domain.test
* staging-domain.laravel.cloud (Default)

Actual redirects:

local-domain.test/logout -> staging-domain.laravel.cloud
staging-domain.laravel.cloud /logout -> staging-domain.laravel.cloud

Preferred redirects: 
local-domain.test/logout -> local-domain.test
staging-domain.laravel.cloud /logout -> staging-domain.laravel.cloud

The first redirect can be achieved by swapping the "Default" in WorkOS but is less ideal.

There's a second optional `$return_to` parameter on `->getLogoutUrl()` that will select one of the configured "Logout redirects" (see https://workos.com/changelog/custom-logout-uris) with a fallback to the configured homepage.