### PR TITLE
pass the full user object to findUsing callback

### DIFF
--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -49,7 +49,7 @@ class AuthKitAuthenticationRequest extends FormRequest
             avatar: $user->profilePictureUrl,
         );
 
-        $existingUser = $findUsing($user->id);
+        $existingUser = $findUsing($user);
 
         if (! $existingUser) {
             $existingUser = $createUsing($user);
@@ -72,10 +72,10 @@ class AuthKitAuthenticationRequest extends FormRequest
     /**
      * Find the user with the given WorkOS ID.
      */
-    protected function findUsing(string $id): ?AppUser
+    protected function findUsing(User $user): ?AppUser
     {
         /** @phpstan-ignore class.notFound */
-        return AppUser::where('workos_id', $id)->first();
+        return AppUser::where('workos_id', $user->id)->first();
     }
 
     /**


### PR DESCRIPTION
NOTE: this is a breaking change. If anyone is passing a custom callback for `findUsing` to `authenticate`, it will need to be updated.

We are trying to support a hybrid login for an existing Laravel application where a subset of users (on a certain domain) use WorkOS, and the rest use the local login logic. We needed to customize `findUsing` to look up a user based on email, not just the `workos_id`, but we were unable to do it since the callback was only being passed the id.

`createUsing` and `updateUsing` deal with full user objects, so this also adds symmetry to the `findUsing` method.

I'd normally add/update tests with a PR, but I don't see any tests. I'd be happy to build out test coverage, but that would be a separate PR.
