### PR TITLE
Feature/add logout return url config

### DIFF
--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -33,7 +33,7 @@ class AuthKitLogoutRequest extends FormRequest
 
         $logoutUrl = (new UserManagement)->getLogoutUrl(
             $workOsSession['sid'],
-            $redirectTo ? url($redirectTo) : null,
+            $redirectTo ? url($redirectTo) : config('services.workos.return_to'),
         );
 
         return class_exists(Inertia::class)

--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -33,7 +33,7 @@ class AuthKitLogoutRequest extends FormRequest
 
         $logoutUrl = (new UserManagement)->getLogoutUrl(
             $workOsSession['sid'],
-            $redirectTo ? url($redirectTo) : config('services.workos.return_to'),
+            $redirectTo ? $redirectTo : config('services.workos.return_to'),
         );
 
         return class_exists(Inertia::class)


### PR DESCRIPTION
  Hey Taylor,

  I ran into an issue when managing multiple Laravel applications that share the same WorkOS account,
   where the logout redirect behavior wasn't flexible enough for multi-app setups.

  Problem:
  When you have multiple Laravel applications using the same WorkOS account with different redirect
  URLs configured in WorkOS, there's currently no way to specify where users should be redirected
  after logout. This creates problems when:

  - Multiple Laravel apps share the same WorkOS account but need different post-logout redirect
  destinations
  - Each app has different redirect URLs configured in WorkOS redirections setup
  - Apps don't have a "home page URL" configured, making the logout redirect throw exception within workos "You don't have home page url"
  - You need to ensure users are redirected to the correct application after logout in a multi-tenant
   setup

  Real-world scenario:
  WorkOS Account Setup:
  ├── App A (staging.myapp.com) - Needs redirect to staging.myapp.com/welcome after logout
  ├── App B (prod.myapp.com) - Needs redirect to prod.myapp.com/welcome after logout
  └── App C (admin.myapp.com) - Needs redirect to admin.myapp.com/login after logout

  Problem: After logout, WorkOS doesn't know which app URL to redirect to

  Proposed solution:
  Add a configurable logout redirect URL so each Laravel app can specify exactly where users should
  be redirected after successful logout:

  config(['workos.logout_redirect_url' => 'https://staging.myapp.com/welcome']);

  If this PR merged i will add this config to laravel workos starter kits.

  Changes made:
  - Added logout_redirect_url configuration option in WorkOS config file

  This is especially important when you have multiple redirect URLs configured in your WorkOS
  redirections setup and need to ensure users are redirected to the correct application after logout,
   particularly when apps don't have a home page URL configured.