### PR TITLE
Allow login redirecturl customization

### DIFF
--- a/src/Http/Requests/AuthKitLoginRequest.php
+++ b/src/Http/Requests/AuthKitLoginRequest.php
@@ -18,7 +18,8 @@ class AuthKitLoginRequest extends FormRequest
      * @param  array{
      *     screenHint?: 'sign-in'|'sign-up',
      *     domainHint?: string,
-     *     loginHint?: string
+     *     loginHint?: string,
+     *     redirectUrl?: string,
      * }  $options
      */
     public function redirect(array $options = []): Response
@@ -26,7 +27,7 @@ class AuthKitLoginRequest extends FormRequest
         WorkOS::configure();
 
         $url = (new UserManagement)->getAuthorizationUrl(
-            config('services.workos.redirect_url'),
+            $options['redirectUrl'] ?? config('services.workos.redirect_url'),
             $state = [
                 'state' => Str::random(20),
                 'previous_url' => base64_encode(URL::previous()),

--- a/tests/Feature/AuthKitLoginRequestTest.php
+++ b/tests/Feature/AuthKitLoginRequestTest.php
@@ -105,14 +105,30 @@ it('supports login hint parameter', function () {
         ->toContain('login_hint='.urlencode('francisco@laravel.com'));
 });
 
+it('uses default redirect URL when not specified', function () {
+    $response = $this->request->redirect();
+
+    expect($response->headers->get('Location'))
+        ->toContain('redirect_uri='.urlencode('https://laravel.com/authenticate'));
+});
+
+it('uses custom redirect URL when specified', function () {
+    $response = $this->request->redirect(['redirectUrl' => 'https://custom.laravel.com/authenticate']);
+
+    expect($response->headers->get('Location'))
+        ->toContain('redirect_uri='.urlencode('https://custom.laravel.com/authenticate'));
+});
+
 it('supports multiple parameters at once', function () {
     $response = $this->request->redirect([
         'screenHint' => 'sign-in',
         'domainHint' => 'laravel.com',
         'loginHint' => 'francisco@laravel.com',
+        'redirectUrl' => 'https://custom.laravel.com/authenticate',
     ]);
 
     expect($response->headers->get('Location'))->toContain('screen_hint=sign-in')
         ->toContain('domain_hint=laravel.com')
-        ->toContain('login_hint='.urlencode('francisco@laravel.com'));
+        ->toContain('login_hint='.urlencode('francisco@laravel.com'))
+        ->toContain('redirect_uri='.urlencode('https://custom.laravel.com/authenticate'));
 });


### PR DESCRIPTION
If a single Laravel app instance runs under multiple domains, it is useful to be able to redirect them back to the correct domain after authenticating at WorkOS.

Currently the redirect URL is specified in config. In order to dynamically change it, you have to override the config value before calling `$request->redirect()`

This small PR adds one additional option following the same pattern as the other options already supported.

Tests were updated.
