### PR TITLE
Add support for custom user model in AuthKitAuthenticationRequest

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,3 @@ parameters:
     - src
 
   level: 0
-
-  ignoreErrors:
-    - '#has invalid (return type|type) App\\Models\\User#'

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -2,10 +2,11 @@
 
 namespace Laravel\WorkOS\Http\Requests;
 
-use App\Models\User as AppUser;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 use Laravel\WorkOS\User;
@@ -72,19 +73,19 @@ class AuthKitAuthenticationRequest extends FormRequest
     /**
      * Find the user with the given WorkOS ID.
      */
-    protected function findUsing(User $user): ?AppUser
+    protected function findUsing(User $user): ?Authenticatable
     {
-        /** @phpstan-ignore class.notFound */
-        return AppUser::where('workos_id', $user->id)->first();
+        $userModelClass = Config::get('auth.providers.users.model');
+        return $userModelClass::where('workos_id', $user->id)->first();
     }
 
     /**
      * Create a user from the given WorkOS user.
      */
-    protected function createUsing(User $user): AppUser
+    protected function createUsing(User $user): Authenticatable
     {
-        /** @phpstan-ignore class.notFound */
-        return AppUser::create([
+        $userModelClass = Config::get('auth.providers.users.model');
+        return $userModelClass::create([
             'name' => $user->firstName.' '.$user->lastName,
             'email' => $user->email,
             'email_verified_at' => now(),
@@ -96,7 +97,7 @@ class AuthKitAuthenticationRequest extends FormRequest
     /**
      * Update a user from the given WorkOS user.
      */
-    protected function updateUsing(AppUser $user, User $userFromWorkOS): AppUser
+    protected function updateUsing(Authenticatable $user, User $userFromWorkOS): Authenticatable
     {
         return tap($user)->update([
             // 'name' => $userFromWorkOS->firstName.' '.$userFromWorkOS->lastName,

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -76,6 +76,7 @@ class AuthKitAuthenticationRequest extends FormRequest
     protected function findUsing(User $user): ?Authenticatable
     {
         $userModelClass = Config::get('auth.providers.users.model');
+
         return $userModelClass::where('workos_id', $user->id)->first();
     }
 
@@ -85,6 +86,7 @@ class AuthKitAuthenticationRequest extends FormRequest
     protected function createUsing(User $user): Authenticatable
     {
         $userModelClass = Config::get('auth.providers.users.model');
+
         return $userModelClass::create([
             'name' => $user->firstName.' '.$user->lastName,
             'email' => $user->email,


### PR DESCRIPTION
**Description:**
- Currently the WorkOS Laravel integration expects the `App\Models\User` to represent a user, but some applications may use a different model.
- Through the Laravel config you typically define an alternative user model, under `auth.providers.users.model` (defaulting to `\App\User\Model` or reading from `AUTH_MODEL` in the .env)
- As such, the `AuthKitAuthenticationRequest` here is updated to take the model from config, and typed to expect a model implementing the `Authenticatable` contract
- This makes the dependency more versatile to Laravel applications that do not use the convention of `\App\Models\User` being the user model.
- Existing Laravel applications which do use the `\App\Models\User` as the user model will not break, assuming they implement the `Authenticatable` contract.

**Tests:**
```
   PASS  Tests\Unit\UnitTest
  ✓ it is true                                                                                                             0.02s

   PASS  Tests\Feature\AuthKitLoginRequestTest
  ✓ it redirects to WorkOS without screen hint                                                                             0.26s
  ✓ it redirects to WorkOS with sign-in screen hint                                                                        0.01s
  ✓ it redirects to WorkOS with sign-up screen hint                                                                        0.01s
  ✓ it stores state in session                                                                                             0.01s
  ✓ it includes state in the authorization URL                                                                             0.01s
  ✓ it passes all parameters correctly to getAuthorizationUrl                                                              0.05s
  ✓ it supports domain hint parameter                                                                                      0.01s
  ✓ it supports login hint parameter                                                                                       0.02s
  ✓ it uses default redirect URL when not specified                                                                        0.03s
  ✓ it uses custom redirect URL when specified                                                                             0.01s
  ✓ it supports multiple parameters at once                                                                                0.01s

   PASS  Tests\Feature\FeatureTest
  ✓ example                                                                                                                0.02s

  Tests:    13 passed (39 assertions)
  Duration: 0.66s
```