### PR TITLE
Allow firebase/php-jwt ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "workos/workos-php": "^4.18",
-        "firebase/php-jwt": "^6.11"
+        "firebase/php-jwt": "^6.11|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
## Summary

- Widens the `firebase/php-jwt` constraint from `^6.11` to `^6.11|^7.0`.
- Allows Composer to resolve to v7.x, which is unaffected by the `PKSA-y2cr-5h3j-g3ys` security advisory that currently blocks v6.11.

## Motivation

Running `composer update` fails because `firebase/php-jwt` v6.11.0 and v6.11.1 are blocked by Composer's `block-insecure` audit policy due to the security advisory. Accepting `^7.0` lets Composer pick the patched major release while keeping backward compatibility with v6.11 for projects that explicitly ignore the advisory.

Made with [Cursor](https://cursor.com)