### PR TITLE
Remove version 6 due to security issue being flaged in composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "workos/workos-php": "^4.18",
-        "firebase/php-jwt": "^6.11|^7.0"
+        "firebase/php-jwt": "^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
I'm dropping version 6 here because on local, when I try to install the dependencies, I'm getting this error:

<img width="1207" height="237" alt="image" src="https://github.com/user-attachments/assets/c561837c-7a2d-467b-89cb-e6fe97293b0c" />

The package seems to be working ok, but there's this warning in the new major release that can affect some apps if they're using keys that doesn't have the correct size:

<img width="704" height="176" alt="image" src="https://github.com/user-attachments/assets/b5fd4e90-4f5b-4675-b3be-557c45d77070" />

