### PR TITLE
Upgrade `workos/workos-php` to V5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.2",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
-        "workos/workos-php": "^4.18",
+        "workos/workos-php": "^5.0",
         "firebase/php-jwt": "^7.0"
     },
     "require-dev": {

--- a/src/Http/Middleware/ValidateSessionWithWorkOS.php
+++ b/src/Http/Middleware/ValidateSessionWithWorkOS.php
@@ -20,8 +20,6 @@ class ValidateSessionWithWorkOS
             return $next($request);
         }
 
-        WorkOS::configure();
-
         if (! $request->session()->get('workos_access_token') ||
             ! $request->session()->get('workos_refresh_token')) {
             return $this->logout($request);

--- a/src/Http/Requests/AuthKitAccountDeletionRequest.php
+++ b/src/Http/Requests/AuthKitAccountDeletionRequest.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Laravel\WorkOS\WorkOS;
-use WorkOS\UserManagement;
 
 class AuthKitAccountDeletionRequest extends FormRequest
 {
@@ -20,10 +19,8 @@ class AuthKitAccountDeletionRequest extends FormRequest
         $user = $this->user();
 
         if (isset($user->workos_id) && ! app()->runningUnitTests()) {
-            WorkOS::configure();
-
-            (new UserManagement)->deleteUser(
-                $user->workos_id
+            WorkOS::client()->userManagement()->deleteUser(
+                $user->workos_id,
             );
         }
 

--- a/src/Http/Requests/AuthKitAuthenticationRequest.php
+++ b/src/Http/Requests/AuthKitAuthenticationRequest.php
@@ -12,7 +12,6 @@ use Inertia\Inertia;
 use Laravel\WorkOS\User;
 use Laravel\WorkOS\WorkOS;
 use Symfony\Component\HttpFoundation\Response;
-use WorkOS\UserManagement;
 
 class AuthKitAuthenticationRequest extends FormRequest
 {
@@ -21,33 +20,23 @@ class AuthKitAuthenticationRequest extends FormRequest
      */
     public function authenticate(?callable $findUsing = null, ?callable $createUsing = null, ?callable $updateUsing = null): mixed
     {
-        WorkOS::configure();
-
         $this->ensureStateIsValid();
 
         $findUsing ??= $this->findUsing(...);
         $createUsing ??= $this->createUsing(...);
         $updateUsing ??= $this->updateUsing(...);
 
-        $user = (new UserManagement)->authenticateWithCode(
-            config('services.workos.client_id'),
-            $this->query('code'),
+        $response = WorkOS::client()->userManagement()->authenticateWithCode(
+            code: $this->query('code'),
         );
 
-        [$user, $accessToken, $refreshToken, $organizationId] = [
-            $user->user,
-            $user->access_token,
-            $user->refresh_token,
-            $user->organizationId,
-        ];
-
         $user = new User(
-            id: $user->id,
-            organizationId: $organizationId,
-            firstName: $user->firstName,
-            lastName: $user->lastName,
-            email: $user->email,
-            avatar: $user->profilePictureUrl,
+            id: $response->user->id,
+            organizationId: $response->organizationId,
+            firstName: $response->user->firstName,
+            lastName: $response->user->lastName,
+            email: $response->user->email,
+            avatar: $response->user->profilePictureUrl,
         );
 
         $existingUser = $findUsing($user);
@@ -62,8 +51,8 @@ class AuthKitAuthenticationRequest extends FormRequest
 
         Auth::guard('web')->login($existingUser);
 
-        $this->session()->put('workos_access_token', $accessToken);
-        $this->session()->put('workos_refresh_token', $refreshToken);
+        $this->session()->put('workos_access_token', $response->accessToken);
+        $this->session()->put('workos_refresh_token', $response->refreshToken);
 
         $this->session()->regenerate();
 

--- a/src/Http/Requests/AuthKitLoginRequest.php
+++ b/src/Http/Requests/AuthKitLoginRequest.php
@@ -39,7 +39,7 @@ class AuthKitLoginRequest extends FormRequest
             'screen_hint' => $options['screenHint'] ?? null,
         ], fn ($value) => $value !== null);
 
-        $url = WorkOS::baseUrl().'/user_management/authorize?'.http_build_query($params);
+        $url = rtrim(WorkOS::baseUrl(), '/').'/user_management/authorize?'.http_build_query($params);
 
         $this->session()->put('state', json_encode($state));
 

--- a/src/Http/Requests/AuthKitLoginRequest.php
+++ b/src/Http/Requests/AuthKitLoginRequest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\WorkOS\WorkOS;
 use Symfony\Component\HttpFoundation\Response;
-use WorkOS\UserManagement;
 
 class AuthKitLoginRequest extends FormRequest
 {
@@ -24,19 +23,23 @@ class AuthKitLoginRequest extends FormRequest
      */
     public function redirect(array $options = []): Response
     {
-        WorkOS::configure();
+        $state = [
+            'state' => Str::random(20),
+            'previous_url' => base64_encode(URL::previous()),
+        ];
 
-        $url = (new UserManagement)->getAuthorizationUrl(
-            $options['redirectUrl'] ?? config('services.workos.redirect_url'),
-            $state = [
-                'state' => Str::random(20),
-                'previous_url' => base64_encode(URL::previous()),
-            ],
-            'authkit',
-            domainHint: $options['domainHint'] ?? null,
-            loginHint: $options['loginHint'] ?? null,
-            screenHint: $options['screenHint'] ?? null,
-        );
+        $params = array_filter([
+            'client_id' => WorkOS::clientId(),
+            'response_type' => 'code',
+            'redirect_uri' => $options['redirectUrl'] ?? WorkOS::redirectUrl(),
+            'provider' => 'authkit',
+            'state' => json_encode($state),
+            'domain_hint' => $options['domainHint'] ?? null,
+            'login_hint' => $options['loginHint'] ?? null,
+            'screen_hint' => $options['screenHint'] ?? null,
+        ], fn ($value) => $value !== null);
+
+        $url = WorkOS::baseUrl().'/user_management/authorize?'.http_build_query($params);
 
         $this->session()->put('state', json_encode($state));
 

--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Laravel\WorkOS\WorkOS;
 use Symfony\Component\HttpFoundation\Response;
-use WorkOS\UserManagement;
 
 class AuthKitLogoutRequest extends FormRequest
 {
@@ -31,10 +30,12 @@ class AuthKitLogoutRequest extends FormRequest
             return redirect($redirectTo ?? '/');
         }
 
-        $logoutUrl = (new UserManagement)->getLogoutUrl(
-            $workOsSession['sid'],
-            $redirectTo ? url($redirectTo) : null,
-        );
+        $params = array_filter([
+            'session_id' => $workOsSession['sid'],
+            'return_to' => $redirectTo ? url($redirectTo) : null,
+        ], fn ($value) => $value !== null);
+
+        $logoutUrl = WorkOS::baseUrl().'/user_management/sessions/logout?'.http_build_query($params);
 
         return class_exists(Inertia::class)
             ? Inertia::location($logoutUrl)

--- a/src/Http/Requests/AuthKitLogoutRequest.php
+++ b/src/Http/Requests/AuthKitLogoutRequest.php
@@ -35,7 +35,7 @@ class AuthKitLogoutRequest extends FormRequest
             'return_to' => $redirectTo ? url($redirectTo) : null,
         ], fn ($value) => $value !== null);
 
-        $logoutUrl = WorkOS::baseUrl().'/user_management/sessions/logout?'.http_build_query($params);
+        $logoutUrl = rtrim(WorkOS::baseUrl(), '/').'/user_management/sessions/logout?'.http_build_query($params);
 
         return class_exists(Inertia::class)
             ? Inertia::location($logoutUrl)

--- a/src/WorkOS.php
+++ b/src/WorkOS.php
@@ -5,33 +5,57 @@ namespace Laravel\WorkOS;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
 use RuntimeException;
 use Throwable;
-use WorkOS\UserManagement;
 use WorkOS\WorkOS as SDK;
 
 class WorkOS
 {
     /**
-     * Ensure WorkOS is configured.
+     * Get the configured WorkOS client ID.
      */
-    public static function configure(): void
+    public static function clientId(): string
     {
-        if (! config('services.workos.client_id')) {
-            throw new RuntimeException("The 'services.workos.client_id' configuration value is undefined.");
-        }
+        return config('services.workos.client_id')
+            ?: throw new RuntimeException("The 'services.workos.client_id' configuration value is undefined.");
+    }
 
-        if (! config('services.workos.secret')) {
-            throw new RuntimeException("The 'services.workos.secret' configuration value is undefined.");
-        }
+    /**
+     * Get the configured WorkOS API secret.
+     */
+    public static function secret(): string
+    {
+        return config('services.workos.secret')
+            ?: throw new RuntimeException("The 'services.workos.secret' configuration value is undefined.");
+    }
 
-        if (! config('services.workos.redirect_url')) {
-            throw new RuntimeException("The 'services.workos.redirect_url' configuration value is undefined.");
-        }
+    /**
+     * Get the configured WorkOS redirect URL.
+     */
+    public static function redirectUrl(): string
+    {
+        return config('services.workos.redirect_url')
+            ?: throw new RuntimeException("The 'services.workos.redirect_url' configuration value is undefined.");
+    }
 
-        SDK::setClientId(config('services.workos.client_id'));
-        SDK::setApiKey(config('services.workos.secret'));
+    /**
+     * Get the configured WorkOS API base URL.
+     */
+    public static function baseUrl(): string
+    {
+        return config('services.workos.base_url', 'https://api.workos.com');
+    }
+
+    /**
+     * Build a configured WorkOS SDK client.
+     */
+    public static function client(): SDK
+    {
+        return new SDK(
+            apiKey: static::secret(),
+            clientId: static::clientId(),
+            baseUrl: static::baseUrl(),
+        );
     }
 
     /**
@@ -39,18 +63,16 @@ class WorkOS
      */
     public static function ensureAccessTokenIsValid(string $accessToken, string $refreshToken): array
     {
-        static::configure();
-
         $workOsSession = static::decodeAccessToken($accessToken);
 
         if (! $workOsSession) {
-            $result = (new UserManagement)->authenticateWithRefreshToken(
-                config('services.workos.client_id'), $refreshToken
+            $result = static::client()->userManagement()->authenticateWithRefreshToken(
+                refreshToken: $refreshToken,
             );
 
             return [
-                $result->access_token,
-                $result->refresh_token,
+                $result->accessToken,
+                $result->refreshToken,
             ];
         }
 
@@ -65,8 +87,6 @@ class WorkOS
      */
     public static function decodeAccessToken(string $accessToken): array|bool
     {
-        static::configure();
-
         try {
             return (array) JWT::decode($accessToken, JWK::parseKeySet(static::getJwk()));
         } catch (Throwable $e) {
@@ -82,9 +102,9 @@ class WorkOS
     protected static function getJwk(): array
     {
         return Cache::remember('workos:jwk', now()->addHours(12), function () {
-            return Http::get(
-                (new UserManagement)->getJwksUrl(config('services.workos.client_id'))
-            )->json();
+            return static::client()->userManagement()->getJwks(
+                static::clientId(),
+            )->toArray();
         });
     }
 }


### PR DESCRIPTION
Later versions of `workos/workos-php` no longer use static getters and setters for configuration. This PR migrates the `laravel` utilities to use the new instantiated, fluent client for `workos` integration.

These changes where made using the following guide:

https://github.com/workos/workos-php/blob/5.0.0/docs/V5_MIGRATION_GUIDE.md

Some notes:
- There is no BC between `v4` and `v5`. This requires a version bump.

- In `v5` there's no static `SDK` state to configure. This PR replaces `Laravel\WorkOs\WorkOs::configure()` with `accessors`:
    - `WorkOs::clientId()`
        - Configuration required 
        - Returns `config('services.workos.client_id')`
        - Throws if missing
    - `WorkOs::secret()`
        - Configuration required
        - Returns `config('services.workos.secret')`
        - Throws if missing
    - `WorkOs::redirectUrl()`
        - Configuration required
        - Returns `config('services.workos.redirect_url')`
        - Throws if missing 
     - `WorkOs::baseUrl()`
        - Configuration optional
        - Returns `config('services.workos.base_url', 'https://api.workos.com')`
        - Defaults to `https://api.workos.com`
        - Can be configured when mocking the api to reduce round trip traffic to `api.workos.com` in local or `testing/ci` environments
     - Validation now happens lazily at point of use.

- `userManagement()->getAuthorizationUrl()` and `getLogoutUrl()` no longer build URL strings, they perform HTTP calls server-side and return response data. So we build both URLs locally against `WorkOS::baseUrl()`.                                                                                                                                                                                                          

- `accessToken`, `refreshToken`, `organizationId` on `WorkOS\Resource\AuthenticateResponse`
    - Response shape is camelCase now. 
    - `v5` resources use readonly typed properties.
- `authenticateWithCode()` and `authenticateWithRefreshToken()` no longer take `clientId` as their first arg, it comes from the instantiated client.

- Tests are untouched