### PR TITLE
Requests for Email & Password Change

### DIFF
--- a/src/Http/Requests/AuthKitEmailChangeRequest.php
+++ b/src/Http/Requests/AuthKitEmailChangeRequest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Laravel\WorkOS\Http\Requests;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Http\FormRequest;
+use Laravel\WorkOS\User;
+use Laravel\WorkOS\WorkOS;
+use RuntimeException;
+use WorkOS\Service\UserManagement;
+
+class AuthKitEmailChangeRequest extends FormRequest
+{
+    /**
+     * Send a WorkOS email change code to the given email address.
+     */
+    public function send(string $email): mixed
+    {
+        $user = $this->workOsUser();
+
+        return $this->userManagement()->sendEmailChange(
+            id: $user->workos_id,
+            newEmail: $email,
+        );
+    }
+
+    /**
+     * Confirm a WorkOS email change and update the application user.
+     */
+    public function confirm(string $code, ?callable $updateUsing = null): mixed
+    {
+        $user = $this->workOsUser();
+
+        $response = $this->userManagement()->confirmEmailChange(
+            id: $user->workos_id,
+            code: $code,
+        );
+
+        $updateUsing ??= $this->updateUsing(...);
+
+        return $updateUsing($user, $this->userFromWorkOS($response->user));
+    }
+
+    /**
+     * Update the application user from the confirmed WorkOS email change.
+     */
+    protected function updateUsing(Authenticatable $user, User $userFromWorkOS): Authenticatable
+    {
+        return tap($user)->update([
+            'email' => $userFromWorkOS->email,
+            'email_verified_at' => now(),
+        ]);
+    }
+
+    /**
+     * Create a Laravel WorkOS user DTO from a WorkOS SDK user resource.
+     */
+    protected function userFromWorkOS(object $user): User
+    {
+        return new User(
+            id: $user->id,
+            organizationId: null,
+            firstName: $user->firstName,
+            lastName: $user->lastName,
+            email: $user->email,
+            avatar: $user->profilePictureUrl,
+        );
+    }
+
+    /**
+     * Get the WorkOS user management client.
+     */
+    protected function userManagement(): UserManagement
+    {
+        return WorkOS::client()->userManagement();
+    }
+
+    /**
+     * Get the authenticated user with a WorkOS ID.
+     */
+    protected function workOsUser(): Authenticatable
+    {
+        $user = $this->user();
+
+        if (! $user || empty($user->workos_id)) {
+            throw new RuntimeException('The authenticated user does not have a WorkOS ID.');
+        }
+
+        return $user;
+    }
+}

--- a/src/Http/Requests/AuthKitEmailChangeRequest.php
+++ b/src/Http/Requests/AuthKitEmailChangeRequest.php
@@ -68,14 +68,6 @@ class AuthKitEmailChangeRequest extends FormRequest
     }
 
     /**
-     * Get the WorkOS user management client.
-     */
-    protected function userManagement(): UserManagement
-    {
-        return WorkOS::client()->userManagement();
-    }
-
-    /**
      * Get the authenticated user with a WorkOS ID.
      */
     protected function workOsUser(): Authenticatable
@@ -87,5 +79,13 @@ class AuthKitEmailChangeRequest extends FormRequest
         }
 
         return $user;
+    }
+
+    /**
+     * Get the WorkOS user management client.
+     */
+    protected function userManagement(): UserManagement
+    {
+        return WorkOS::client()->userManagement();
     }
 }

--- a/src/Http/Requests/AuthKitPasswordChangeRequest.php
+++ b/src/Http/Requests/AuthKitPasswordChangeRequest.php
@@ -15,8 +15,7 @@ class AuthKitPasswordChangeRequest extends FormRequest
      */
     public function send(): mixed
     {
-        $user = $this->workOsUser();
-        $userManagement = $this->userManagement();
+        [$user, $userManagement] = [$this->workOsUser(), $this->userManagement()];
 
         $userFromWorkOS = $userManagement->getUser(
             id: $user->workos_id,
@@ -25,14 +24,6 @@ class AuthKitPasswordChangeRequest extends FormRequest
         return $userManagement->resetPassword(
             email: $userFromWorkOS->email,
         );
-    }
-
-    /**
-     * Get the WorkOS user management client.
-     */
-    protected function userManagement(): UserManagement
-    {
-        return WorkOS::client()->userManagement();
     }
 
     /**
@@ -47,5 +38,13 @@ class AuthKitPasswordChangeRequest extends FormRequest
         }
 
         return $user;
+    }
+
+    /**
+     * Get the WorkOS user management client.
+     */
+    protected function userManagement(): UserManagement
+    {
+        return WorkOS::client()->userManagement();
     }
 }

--- a/src/Http/Requests/AuthKitPasswordChangeRequest.php
+++ b/src/Http/Requests/AuthKitPasswordChangeRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\WorkOS\Http\Requests;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Http\FormRequest;
+use Laravel\WorkOS\WorkOS;
+use RuntimeException;
+use WorkOS\Service\UserManagement;
+
+class AuthKitPasswordChangeRequest extends FormRequest
+{
+    /**
+     * Send a WorkOS password reset email to the authenticated user.
+     */
+    public function send(): mixed
+    {
+        $user = $this->workOsUser();
+        $userManagement = $this->userManagement();
+
+        $userFromWorkOS = $userManagement->getUser(
+            id: $user->workos_id,
+        );
+
+        return $userManagement->resetPassword(
+            email: $userFromWorkOS->email,
+        );
+    }
+
+    /**
+     * Get the WorkOS user management client.
+     */
+    protected function userManagement(): UserManagement
+    {
+        return WorkOS::client()->userManagement();
+    }
+
+    /**
+     * Get the authenticated user with a WorkOS ID.
+     */
+    protected function workOsUser(): Authenticatable
+    {
+        $user = $this->user();
+
+        if (! $user || empty($user->workos_id)) {
+            throw new RuntimeException('The authenticated user does not have a WorkOS ID.');
+        }
+
+        return $user;
+    }
+}

--- a/tests/Feature/AuthKitEmailChangeRequestTest.php
+++ b/tests/Feature/AuthKitEmailChangeRequestTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Laravel\WorkOS\Http\Requests\AuthKitEmailChangeRequest;
+use Laravel\WorkOS\User as LaravelWorkOSUser;
+use Tests\Fixtures\FakeUser;
+use Tests\Fixtures\WorkOSResourceFactory;
+use WorkOS\Resource\EmailChange;
+use WorkOS\Resource\EmailChangeConfirmation;
+use WorkOS\Service\UserManagement;
+
+beforeEach(function () {
+    $this->userManagement = Mockery::mock(UserManagement::class);
+
+    $this->user = new FakeUser;
+
+    $this->request = new class extends AuthKitEmailChangeRequest
+    {
+        public UserManagement $userManagement;
+
+        protected function userManagement(): UserManagement
+        {
+            return $this->userManagement;
+        }
+    };
+
+    $this->request->userManagement = $this->userManagement;
+    $this->request->setUserResolver(fn () => $this->user);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('sends a WorkOS email change code', function () {
+    $emailChange = EmailChange::fromArray([
+        'object' => 'email_change',
+        'user' => WorkOSResourceFactory::userArray(),
+        'new_email' => 'new@example.com',
+        'expires_at' => '2026-05-19T12:15:00.000Z',
+        'created_at' => '2026-05-19T12:00:00.000Z',
+    ]);
+
+    $this->userManagement
+        ->shouldReceive('sendEmailChange')
+        ->once()
+        ->with('user_123', 'new@example.com')
+        ->andReturn($emailChange);
+
+    expect($this->request->send('new@example.com'))->toBe($emailChange);
+});
+
+it('confirms a WorkOS email change and updates the authenticated user', function () {
+    $emailChangeConfirmation = EmailChangeConfirmation::fromArray([
+        'object' => 'email_change_confirmation',
+        'user' => WorkOSResourceFactory::userArray(['email' => 'new@example.com']),
+    ]);
+
+    $this->userManagement
+        ->shouldReceive('confirmEmailChange')
+        ->once()
+        ->with('user_123', '123456')
+        ->andReturn($emailChangeConfirmation);
+
+    $user = $this->request->confirm('123456');
+
+    expect($user)->toBe($this->user)
+        ->and($this->user->email)->toBe('new@example.com')
+        ->and($this->user->updated)->toHaveKey('email')
+        ->and($this->user->updated)->toHaveKey('email_verified_at');
+});
+
+it('allows customizing how confirmed email changes update the authenticated user', function () {
+    $emailChangeConfirmation = EmailChangeConfirmation::fromArray([
+        'object' => 'email_change_confirmation',
+        'user' => WorkOSResourceFactory::userArray([
+            'first_name' => 'Taylor',
+            'last_name' => 'Otwell',
+            'email' => 'new@example.com',
+        ]),
+    ]);
+
+    $this->userManagement
+        ->shouldReceive('confirmEmailChange')
+        ->once()
+        ->with('user_123', '123456')
+        ->andReturn($emailChangeConfirmation);
+
+    $result = $this->request->confirm('123456', function (FakeUser $user, LaravelWorkOSUser $userFromWorkOS) {
+        $user->update([
+            'email' => $userFromWorkOS->email,
+            'name' => $userFromWorkOS->firstName.' '.$userFromWorkOS->lastName,
+        ]);
+
+        return 'updated';
+    });
+
+    expect($result)->toBe('updated')
+        ->and($this->user->email)->toBe('new@example.com')
+        ->and($this->user->name)->toBe('Taylor Otwell');
+});
+
+it('requires the authenticated user to have a WorkOS ID', function () {
+    $this->request->setUserResolver(fn () => new FakeUser(workos_id: null));
+
+    $this->request->send('new@example.com');
+})->throws(RuntimeException::class, 'The authenticated user does not have a WorkOS ID.');

--- a/tests/Feature/AuthKitPasswordChangeRequestTest.php
+++ b/tests/Feature/AuthKitPasswordChangeRequestTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Laravel\WorkOS\Http\Requests\AuthKitPasswordChangeRequest;
+use Tests\Fixtures\FakeUser;
+use Tests\Fixtures\WorkOSResourceFactory;
+use WorkOS\Resource\PasswordReset;
+use WorkOS\Resource\User;
+use WorkOS\Service\UserManagement;
+
+beforeEach(function () {
+    $this->userManagement = Mockery::mock(UserManagement::class);
+
+    $this->user = new FakeUser(email: 'stale@example.com');
+
+    $this->request = new class extends AuthKitPasswordChangeRequest
+    {
+        public UserManagement $userManagement;
+
+        protected function userManagement(): UserManagement
+        {
+            return $this->userManagement;
+        }
+    };
+
+    $this->request->userManagement = $this->userManagement;
+    $this->request->setUserResolver(fn () => $this->user);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('sends a password reset email to the current WorkOS email address', function () {
+    $userFromWorkOS = User::fromArray(WorkOSResourceFactory::userArray([
+        'email' => 'current@example.com',
+    ]));
+
+    $passwordReset = PasswordReset::fromArray([
+        'object' => 'password_reset',
+        'id' => 'password_reset_123',
+        'user_id' => 'user_123',
+        'email' => 'current@example.com',
+        'expires_at' => '2026-05-19T12:15:00.000Z',
+        'created_at' => '2026-05-19T12:00:00.000Z',
+        'password_reset_token' => 'token_123',
+        'password_reset_url' => 'https://authkit.example.com/reset-password?token=token_123',
+    ]);
+
+    $this->userManagement
+        ->shouldReceive('getUser')
+        ->once()
+        ->with('user_123')
+        ->andReturn($userFromWorkOS);
+
+    $this->userManagement
+        ->shouldReceive('resetPassword')
+        ->once()
+        ->with('current@example.com')
+        ->andReturn($passwordReset);
+
+    expect($this->request->send())->toBe($passwordReset);
+});
+
+it('requires the authenticated user to have a WorkOS ID', function () {
+    $this->request->setUserResolver(fn () => new FakeUser(workos_id: null));
+
+    $this->request->send();
+})->throws(RuntimeException::class, 'The authenticated user does not have a WorkOS ID.');

--- a/tests/Fixtures/FakeUser.php
+++ b/tests/Fixtures/FakeUser.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class FakeUser extends Authenticatable
+{
+    public array $updated = [];
+
+    public function __construct(
+        public ?string $workos_id = 'user_123',
+        public string $email = 'old@example.com',
+    ) {
+        parent::__construct();
+    }
+
+    public function update(array $attributes = [], array $options = [])
+    {
+        $this->updated = array_merge($this->updated, $attributes);
+
+        foreach ($attributes as $key => $value) {
+            $this->{$key} = $value;
+        }
+
+        return true;
+    }
+}

--- a/tests/Fixtures/WorkOSResourceFactory.php
+++ b/tests/Fixtures/WorkOSResourceFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class WorkOSResourceFactory
+{
+    public static function userArray(array $overrides = []): array
+    {
+        return array_merge([
+            'object' => 'user',
+            'id' => 'user_123',
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'profile_picture_url' => 'https://example.com/avatar.jpg',
+            'email' => 'old@example.com',
+            'email_verified' => true,
+            'external_id' => null,
+            'last_sign_in_at' => null,
+            'created_at' => '2026-05-19T11:00:00.000Z',
+            'updated_at' => '2026-05-19T12:00:00.000Z',
+            'metadata' => null,
+            'locale' => null,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Motivation

As a Laravel WorkOS Starterkit user, I would like to make it possible for my logged-in users to request a password change and to change their email address. This lays the foundation for that change by exposing small request helpers around the relevant WorkOS AuthKit user-management APIs.

## Changes

- Add `AuthKitPasswordChangeRequest` for triggering a WorkOS password reset/change email for the authenticated user.
- Add `AuthKitEmailChangeRequest` for sending and confirming WorkOS email-change codes.
- Update the local Laravel user email only after WorkOS confirms the email change.
- Allow applications to customize the local email-change update via callback, matching the existing package style.
- Add focused feature tests for password-change email and email-change flows.

## Notes

- This does not implement logged-out forgot-password behavior; AuthKit already handles that from the hosted login screen.
- This does not add UI or routes. Starter kits can decide when to expose these helpers based on their product/auth configuration.
- WorkOS remains the source of truth for whether password/email-change flows are allowed. This change however makes it possible to extend the `/settings/profile` in Laravel WorkOS starterkits with email and password change functionality.

## Verification

- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`